### PR TITLE
Fix bag with clickToCopy

### DIFF
--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -23,12 +23,13 @@
                             :row="$row"
                             :theme="$theme->editable"
                             :field="$column->dataField != '' ? $column->dataField : $column->field"/>
-
-                        <x-livewire-powergrid::click-to-copy
-                            :row="$row"
-                            :field="$content"
-                            :label="$column->click_to_copy['label'] ?? null"
-                            :enabled="$column->click_to_copy['enabled'] ?? false"/>
+                        @if($column->clickToCopy)
+                            <x-livewire-powergrid::click-to-copy
+                                :row="$row"
+                                :field="$content"
+                                :label="data_get($column->clickToCopy, 'label') ?? null"
+                                :enabled="data_get($column->clickToCopy, 'enabled') ?? false"/>
+                        @endif
                     </span>
 
             @elseif(count($column->toggleable) > 0)
@@ -38,11 +39,13 @@
                     <div>
                         {!! $content !!}
                     </div>
-                    <x-livewire-powergrid::click-to-copy
-                        :row="$row"
-                        :field="$content"
-                        :label="data_get($column->clickToCopy, 'label') ?? null"
-                        :enabled="data_get($column->clickToCopy, 'enabled') ?? false"/>
+                    @if($column->clickToCopy)
+                        <x-livewire-powergrid::click-to-copy
+                            :row="$row"
+                            :field="$content"
+                            :label="data_get($column->clickToCopy, 'label') ?? null"
+                            :enabled="data_get($column->clickToCopy, 'enabled') ?? false"/>
+                    @endif
                 </span>
             @endif
         </td>


### PR DESCRIPTION
We do a preliminary check for the presence of truth in the "`clickToCopy`" property, so as not to call more components in 2x empty than to slow down the work of tables.

Before
<img width="1679" alt="Снимок экрана 2021-12-04 в 11 33 26" src="https://user-images.githubusercontent.com/59070939/144704803-cd18e3ca-7b1f-47e3-9187-d06cea8f68b2.png">

After
<img width="1674" alt="Снимок экрана 2021-12-04 в 11 33 43" src="https://user-images.githubusercontent.com/59070939/144704804-f113432b-6d5f-47a7-9320-0713f5987295.png">
